### PR TITLE
[FIX] Fix code coverage by switching format to SonarQube generic format

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - sh: dotnet tool install --global dotnet-sonarscanner
   - sh: dotnet tool install --global dotnet-reportgenerator-globaltool
 before_build:
-  - sh: dotnet sonarscanner begin /k:pikenikes_rules-framework /v:$APPVEYOR_BUILD_VERSION /o:pikenikes-github /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866 /d:sonar.coverage.exclusions="tests/*Tests/**" /d:sonar.cs.opencover.reportsPaths="coverage-outputs/coverage.opencover.xml" /d:sonar.branch.name=$APPVEYOR_REPO_BRANCH
+  - sh: dotnet sonarscanner begin /k:pikenikes_rules-framework /v:$APPVEYOR_BUILD_VERSION /o:pikenikes-github /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866 /d:sonar.coverage.exclusions="tests/*Tests/**" /d:sonar.cs.opencover.reportsPaths="coverage-outputs/Cobertura.xml" /d:sonar.branch.name=$APPVEYOR_REPO_BRANCH
 build_script:
   - sh: dotnet restore rules-framework.sln --no-cache
   - sh: dotnet build rules-framework.sln --no-restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ build_script:
   - sh: dotnet pack src/Rules.Framework.Providers.MongoDb/Rules.Framework.Providers.MongoDb.csproj --no-build --include-symbols
 test_script:
   - sh: dotnet test rules-framework.sln --no-build --collect:"XPlat Code Coverage" --results-directory:"../../coverage-outputs" -m:1
-  - sh: pwd
   - sh: reportgenerator -reports:"../../coverage-outputs/**/*.xml" -targetdir:"../../coverage-outputs" -reporttypes:SonarQube
   - sh: rm -rfv ../../coverage-outputs/*/
   - sh: ls -la ../../coverage-outputs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ test_script:
   - sh: dotnet test rules-framework.sln --no-build --collect:"XPlat Code Coverage" --results-directory:"../../coverage-outputs" -m:1
   - sh: reportgenerator -reports:"../../coverage-outputs/**/*.xml" -targetdir:"../../coverage-outputs" -reporttypes:Cobertura
   - sh: rm -rfv ../../coverage-outputs/*/
+  - sh: ll
 after_test:
   - sh: dotnet sonarscanner end /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - sh: dotnet tool install --global dotnet-sonarscanner
   - sh: dotnet tool install --global dotnet-reportgenerator-globaltool
 before_build:
-  - sh: dotnet sonarscanner begin /k:pikenikes_rules-framework /v:$APPVEYOR_BUILD_VERSION /o:pikenikes-github /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866 /d:sonar.coverage.exclusions="tests/*Tests/**" /d:sonar.cs.opencover.reportsPaths="../../coverage-outputs/Cobertura.xml" /d:sonar.branch.name=$APPVEYOR_REPO_BRANCH
+  - sh: dotnet sonarscanner begin /k:pikenikes_rules-framework /v:$APPVEYOR_BUILD_VERSION /o:pikenikes-github /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866 /d:sonar.coverage.exclusions="tests/*Tests/**" /d:sonar.coverageReportPaths="../../coverage-outputs/SonarQube.xml" /d:sonar.branch.name=$APPVEYOR_REPO_BRANCH
 build_script:
   - sh: dotnet restore rules-framework.sln --no-cache
   - sh: dotnet build rules-framework.sln --no-restore
@@ -22,7 +22,8 @@ build_script:
   - sh: dotnet pack src/Rules.Framework.Providers.MongoDb/Rules.Framework.Providers.MongoDb.csproj --no-build --include-symbols
 test_script:
   - sh: dotnet test rules-framework.sln --no-build --collect:"XPlat Code Coverage" --results-directory:"../../coverage-outputs" -m:1
-  - sh: reportgenerator -reports:"../../coverage-outputs/**/*.xml" -targetdir:"../../coverage-outputs" -reporttypes:Cobertura
+  - sh: pwd
+  - sh: reportgenerator -reports:"../../coverage-outputs/**/*.xml" -targetdir:"../../coverage-outputs" -reporttypes:SonarQube
   - sh: rm -rfv ../../coverage-outputs/*/
   - sh: ls -la ../../coverage-outputs
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ test_script:
   - sh: dotnet test rules-framework.sln --no-build --collect:"XPlat Code Coverage" --results-directory:"../../coverage-outputs" -m:1
   - sh: reportgenerator -reports:"../../coverage-outputs/**/*.xml" -targetdir:"../../coverage-outputs" -reporttypes:Cobertura
   - sh: rm -rfv ../../coverage-outputs/*/
-  - sh: ll
+  - sh: ls -la
 after_test:
   - sh: dotnet sonarscanner end /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
 test_script:
   - sh: dotnet test rules-framework.sln --no-build --collect:"XPlat Code Coverage" --results-directory:"../../coverage-outputs" -m:1
   - sh: reportgenerator -reports:"../../coverage-outputs/**/*.xml" -targetdir:"../../coverage-outputs" -reporttypes:Cobertura
-  - sh: rm -rf ../../coverage-outputs/*/
+  - sh: rm -rfv ../../coverage-outputs/*/
 after_test:
   - sh: dotnet sonarscanner end /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - sh: dotnet tool install --global dotnet-sonarscanner
   - sh: dotnet tool install --global dotnet-reportgenerator-globaltool
 before_build:
-  - sh: dotnet sonarscanner begin /k:pikenikes_rules-framework /v:$APPVEYOR_BUILD_VERSION /o:pikenikes-github /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866 /d:sonar.coverage.exclusions="tests/*Tests/**" /d:sonar.cs.opencover.reportsPaths="coverage-outputs/Cobertura.xml" /d:sonar.branch.name=$APPVEYOR_REPO_BRANCH
+  - sh: dotnet sonarscanner begin /k:pikenikes_rules-framework /v:$APPVEYOR_BUILD_VERSION /o:pikenikes-github /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866 /d:sonar.coverage.exclusions="tests/*Tests/**" /d:sonar.cs.opencover.reportsPaths="../../coverage-outputs/Cobertura.xml" /d:sonar.branch.name=$APPVEYOR_REPO_BRANCH
 build_script:
   - sh: dotnet restore rules-framework.sln --no-cache
   - sh: dotnet build rules-framework.sln --no-restore
@@ -24,7 +24,7 @@ test_script:
   - sh: dotnet test rules-framework.sln --no-build --collect:"XPlat Code Coverage" --results-directory:"../../coverage-outputs" -m:1
   - sh: reportgenerator -reports:"../../coverage-outputs/**/*.xml" -targetdir:"../../coverage-outputs" -reporttypes:Cobertura
   - sh: rm -rfv ../../coverage-outputs/*/
-  - sh: ls -la
+  - sh: ls -la ../../coverage-outputs
 after_test:
   - sh: dotnet sonarscanner end /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866
 artifacts:

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -11,7 +11,7 @@ $coverageDir = "$currentDir\\coverage-outputs\\$reportTimestamp\\"
 
 dotnet test .\rules-framework.sln --collect:"XPlat Code Coverage" --results-directory:"$coverageDir" -m:1
 
-reportgenerator -reports:"$($coverageDir)*\\*.xml" -targetdir:"$($coverageDir)" -reporttypes:Cobertura
+reportgenerator -reports:"$($coverageDir)*\\*.xml" -targetdir:"$($coverageDir)" -reporttypes:SonarQube
 
 $coverageFile = "$($coverageDir)*.xml"
 $coverageReportFolder = "$($currentDir)\\coverage-outputs\\report\\"

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -11,7 +11,7 @@ $coverageDir = "$currentDir\\coverage-outputs\\$reportTimestamp\\"
 
 dotnet test .\rules-framework.sln --collect:"XPlat Code Coverage" --results-directory:"$coverageDir" -m:1
 
-reportgenerator -reports:"$($coverageDir)*\\*.xml" -targetdir:"$($coverageDir)" -reporttypes:SonarQube
+reportgenerator -reports:"$($coverageDir)*\\*.xml" -targetdir:"$($coverageDir)" -reporttypes:Cobertura
 
 $coverageFile = "$($coverageDir)*.xml"
 $coverageReportFolder = "$($currentDir)\\coverage-outputs\\report\\"


### PR DESCRIPTION
Adapts build scripting to recover SonarQube code coverage metrics. Now using SonarQube default format for code coverage upload.